### PR TITLE
Resize bitvector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>de.tudresden.inf.lat.wikihypergraph</groupId>
 	<artifactId>wikihypergraph-parent</artifactId>
-	<version>0.0.1</version>
+	<version>0.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/wikihypergraph/pom.xml
+++ b/wikihypergraph/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>de.tudresden.inf.lat.wikihypergraph</groupId>
 	<artifactId>wikihypergraph</artifactId>
-	<version>0.0.1</version>
+	<version>0.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/wikihypergraph/src/main/java/de/tudresden/inf/lat/wikihypergraph/main/Main.java
+++ b/wikihypergraph/src/main/java/de/tudresden/inf/lat/wikihypergraph/main/Main.java
@@ -45,7 +45,7 @@ public class Main {
 		controller.registerMwRevisionProcessor(mwRevisionProcessor, null, true);
 
 		// this processes the most recent dump file
-		controller.processAllRecentRevisionDumps();
+		controller.processMostRecentJsonDump();
 	}
 
 	public void run() throws IOException {

--- a/wikihypergraph/src/main/java/de/tudresden/inf/lat/wikihypergraph/main/Main.java
+++ b/wikihypergraph/src/main/java/de/tudresden/inf/lat/wikihypergraph/main/Main.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.Writer;
 
 import org.wikidata.wdtk.dumpfiles.DumpProcessingController;
+import org.wikidata.wdtk.dumpfiles.WdhgDumpProcessingController;
 
 /**
  * This is the main class to process the dump files.
@@ -14,6 +15,14 @@ import org.wikidata.wdtk.dumpfiles.DumpProcessingController;
 public class Main {
 
 	public static final String WIKIDATAWIKI = "wikidatawiki";
+
+	// the bit vector size of pages is only needed when using Wikidata Toolkit
+	// v0.4.0 (or previous versions)
+	public static final long MAX_PAGES = 100000000;
+
+	// the bit vector size of revisions is only needed when using Wikidata
+	// Toolkit v0.4.0 (or previous versions)
+	public static final long MAX_REVISIONS = 1000000000;
 
 	private String outputFileName = "output.txt";
 
@@ -32,16 +41,16 @@ public class Main {
 		EntityMwRevisionProcessor mwRevisionProcessor = new EntityMwRevisionProcessor(
 				output);
 
-		// This registers the processor
+		// this registers the processor
 		controller.registerMwRevisionProcessor(mwRevisionProcessor, null, true);
 
-		// This processes the most recent dump
+		// this processes the most recent dump file
 		controller.processAllRecentRevisionDumps();
 	}
 
 	public void run() throws IOException {
-		DumpProcessingController controller = new DumpProcessingController(
-				WIKIDATAWIKI);
+		DumpProcessingController controller = new WdhgDumpProcessingController(
+				WIKIDATAWIKI, MAX_PAGES, MAX_REVISIONS);
 		FileWriter writer = new FileWriter(this.outputFileName);
 
 		processDump(controller, writer);

--- a/wikihypergraph/src/main/java/org/wikidata/wdtk/dumpfiles/WdhgDumpProcessingController.java
+++ b/wikihypergraph/src/main/java/org/wikidata/wdtk/dumpfiles/WdhgDumpProcessingController.java
@@ -1,0 +1,39 @@
+package org.wikidata.wdtk.dumpfiles;
+
+/**
+ * This class is a wrapper of {@link DumpProcessingController}, to use Wikidata
+ * Toolkit v0.4.0 (or previous versions).
+ * 
+ * 
+ * @author Julian Mendez
+ * 
+ */
+public class WdhgDumpProcessingController extends DumpProcessingController {
+
+	long maxPages;
+	long maxRevisions;
+
+	/**
+	 * Constructs a new dump processing controller.
+	 * 
+	 * @param projectName
+	 *            project name
+	 * @param maxPages
+	 *            maximum size of bit vector of pages
+	 * @param maxRevisions
+	 *            maximum size of bit vector of revisions
+	 */
+	public WdhgDumpProcessingController(String projectName, long maxPages,
+			long maxRevisions) {
+		super(projectName);
+		this.maxPages = maxPages;
+		this.maxRevisions = maxRevisions;
+	}
+
+	MwDumpFileProcessor getRevisionDumpFileProcessor() {
+		return new MwRevisionDumpFileProcessor(
+				new WdhgMwRevisionProcessorBroker(this.maxPages,
+						this.maxRevisions));
+	}
+
+}

--- a/wikihypergraph/src/main/java/org/wikidata/wdtk/dumpfiles/WdhgMwRevisionProcessorBroker.java
+++ b/wikihypergraph/src/main/java/org/wikidata/wdtk/dumpfiles/WdhgMwRevisionProcessorBroker.java
@@ -1,0 +1,29 @@
+package org.wikidata.wdtk.dumpfiles;
+
+import org.wikidata.wdtk.storage.datastructures.BitVectorImpl;
+
+/**
+ * This class is a wrapper of {@link MwRevisionProcessorBroker}, to use Wikidata
+ * Toolkit v0.4.0 (or previous versions).
+ * 
+ * @author Julian Mendez
+ * 
+ */
+public class WdhgMwRevisionProcessorBroker extends MwRevisionProcessorBroker {
+
+	/**
+	 * Constructs a new revision processor broker.
+	 * 
+	 * @param maxPages
+	 *            maximum size of bit vector of pages
+	 * @param maxRevisions
+	 *            maximum size of bit vector of revisions
+	 */
+
+	public WdhgMwRevisionProcessorBroker(long maxPages, long maxRevisions) {
+		super();
+		encounteredPages = new BitVectorImpl(maxPages);
+		encounteredRevisions = new BitVectorImpl(maxRevisions);
+	}
+
+}


### PR DESCRIPTION
The bit vectors used to index pages and revisions can have different initial sizes from those given in Wikidata Toolkit v0.4.0.
